### PR TITLE
Timeouts & TTLs

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -162,6 +162,13 @@ func (c *Conn) Close() {
 	}
 }
 
+// CloseConnection closes the underlying network connection to zookeeper
+// This will trigger both the send and recv loops to exit and requests to flush
+// and then we will automatically attempt to reconnect
+func (c *Conn) CloseConnection() error {
+	return c.conn.Close()
+}
+
 // SetRequestTimeout allows the default request timeout to be overridden for this connection
 // @todo support per request timeouts
 func (c *Conn) SetRequestTimeout(d time.Duration) error {

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -162,10 +162,10 @@ func (c *Conn) Close() {
 	}
 }
 
-// CloseConnection closes the underlying network connection to zookeeper
+// Reconnect closes the underlying network connection to zookeeper
 // This will trigger both the send and recv loops to exit and requests to flush
 // and then we will automatically attempt to reconnect
-func (c *Conn) CloseConnection() error {
+func (c *Conn) Reconnect() error {
 	return c.conn.Close()
 }
 

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -632,7 +632,7 @@ func (c *Conn) request(opcode int32, req interface{}, res interface{}, recvFunc 
 			delete(c.requests, xid)
 		}
 
-		return -1, fmt.Errorf("Request timed out after %v", c.requestTimeout)
+		return -1, ErrRequestTimeout
 	}
 }
 

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -621,7 +621,7 @@ func (c *Conn) request(opcode int32, req interface{}, res interface{}, recvFunc 
 		// Request timed out, clean up
 		// @todo actually clean up
 		log.Warnf("[Zookeeper] Request timed out after %v", c.requestTimeout)
-		return 0, fmt.Errorf("Request timed out after %v", c.requestTimeout)
+		return -1, fmt.Errorf("Request timed out after %v", c.requestTimeout)
 	}
 }
 

--- a/zk/constants.go
+++ b/zk/constants.go
@@ -115,6 +115,7 @@ var (
 	ErrClosing                 = errors.New("zk: zookeeper is closing")
 	ErrNothing                 = errors.New("zk: no server responsees to process")
 	ErrSessionMoved            = errors.New("zk: session moved to another server, so operation is ignored")
+	ErrRequestTimeout          = errors.New("zk: request timed out")
 
 	// ErrInvalidCallback         = errors.New("zk: invalid callback specified")
 	errCodeToError = map[ErrCode]error{


### PR DESCRIPTION
Very much a work in progress, but attempts to put a deadline on all requests to Zookeeper. This will hopefully fix a number of suspected problems where calls to the library might never return.
- [x] Switch logging to `seelog`, rather than `log` so we have more control over log levels
- [x] Allow a custom request timeout to be set on a connection, defaults to `3s` which is probably far too high.
- [x] Abandon requests which exceed the request timeout - applies to all requests
- [x] Split apart timeouts and TTLs on Locks, allowing these to be set independently
- [x] Return `ErrRequestTimeout` on request timeout

Unrelated, but used by the Lock implementation
- [x] Add `Reconnect()` method which kills the ZK connection forcing a reconnect _...something something danger zone_

For the moment I'm not going to implement per request timeouts, as it's going to take me too long. One way would be a background worker running off a queue ordered by TTL (eg. [a priority queue](http://en.wikipedia.org/wiki/Priority_queue), [example](http://golang.org/pkg/container/heap/#example)) which on TTL expiry of a request fired a timeout error down the response channel.
