### PR TITLE
Simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Native Go Zookkeeper Client Library
+Native Go Zookeeper Client Library
 ===================================
 
 [![Build Status](https://travis-ci.org/samuel/go-zookeeper.png)](https://travis-ci.org/samuel/go-zookeeper)

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -524,7 +524,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 			case EventNodeCreated:
 				wTypes = append(wTypes, watchTypeExist)
 			case EventNodeDeleted, EventNodeDataChanged:
-				wTypes = append(wTypes, watchTypeExist, watchTypeData)
+				wTypes = append(wTypes, watchTypeExist, watchTypeData, watchTypeChild)
 			case EventNodeChildrenChanged:
 				wTypes = append(wTypes, watchTypeChild)
 			}

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -523,7 +523,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 			switch res.Type {
 			case EventNodeCreated:
 				wTypes = append(wTypes, watchTypeExist)
-			case EventNodeDeleted, EventNodeDataChanged:
+			case EventNodeDeleted, EventNodeDataChanged, EventSession:
 				wTypes = append(wTypes, watchTypeExist, watchTypeData, watchTypeChild)
 			case EventNodeChildrenChanged:
 				wTypes = append(wTypes, watchTypeChild)

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -556,7 +556,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 			c.requestsLock.Unlock()
 
 			if !ok {
-				log.Warnf("Received response for unrecognised transaction %d", res.Xid)
+				log.Warnf("[Zookeeper] Received response for unrecognised transaction %d", res.Xid)
 			} else {
 				if res.Err != 0 {
 					err = res.Err.toError()

--- a/zk/lock.go
+++ b/zk/lock.go
@@ -144,10 +144,12 @@ func (l *Lock) findLowestSequenceNode(seq int) (lowestSeq int, prevSeqPath strin
 		// check if this lock has timed out TODO keep this?
 		data, _, _ := l.c.Get(l.path + "/" + p)
 		if len(data) > 0 {
-			ttl.GobDecode(data)
-			if ttl.Before(time.Now()) {
-				l.c.Delete(l.path+"/"+p, -1)
-				continue
+			err := ttl.GobDecode(data)
+			if err == nil { // data might not be a time
+				if ttl.Before(time.Now()) {
+					l.c.Delete(l.path+"/"+p, -1)
+					continue
+				}
 			}
 		}
 

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -222,6 +222,33 @@ func TestChildWatch(t *testing.T) {
 	case _ = <-time.After(time.Second * 2):
 		t.Fatal("Child watcher timed out")
 	}
+
+	// Delete of the watched node should trigger the watch
+
+	children, stat, childCh, err = zk.ChildrenW("/gozk-test")
+	if err != nil {
+		t.Fatalf("Children returned error: %+v", err)
+	} else if stat == nil {
+		t.Fatal("Children returned nil stat")
+	} else if len(children) != 0 {
+		t.Fatal("Children should return 0 children")
+	}
+
+	if err := zk.Delete("/gozk-test", -1); err != nil && err != ErrNoNode {
+		t.Fatalf("Delete returned error: %+v", err)
+	}
+
+	select {
+	case ev := <-childCh:
+		if ev.Err != nil {
+			t.Fatalf("Child watcher error %+v", ev.Err)
+		}
+		if ev.Path != "/gozk-test" {
+			t.Fatalf("Child watcher wrong path %s instead of %s", ev.Path, "/")
+		}
+	case _ = <-time.After(time.Second * 2):
+		t.Fatal("Child watcher timed out")
+	}
 }
 
 func TestSetWatchers(t *testing.T) {


### PR DESCRIPTION
Remove request timeouts
Simplify locking recipe. Use simpler approach to lock acquisition timeout.
